### PR TITLE
Update rainbow_inverted.svg

### DIFF
--- a/rainbow/rainbow_inverted.svg
+++ b/rainbow/rainbow_inverted.svg
@@ -227,7 +227,7 @@
          d="m 0,291.70834 h 5.2916665 v 1.76389 H 0 Z"
          id="rect3597" />
       <path
-         style="fill:#e80523 icc-color(sRGB, 0.90998703, 0.01971466, 0.13713283);fill-opacity:1;stroke-width:0.00866485"
+         style="fill:#e80523;fill-opacity:1;stroke-width:0.00866485"
          d="m 0,291.70834 h 5.2916665 v 0.88195 H 0 Z"
          id="rect3599" />
     </g>


### PR DESCRIPTION
removed unnecessary "icc-color" attribute of red shape because it showed up black instead in eg. Chrome, macOS